### PR TITLE
cargo: decrease needed edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "neon-beat-back"
 version = "0.9.0"
-edition = "2024"
+edition = "2021"
 
 [features]
 default = ["mongo-store", "couch-store"]


### PR DESCRIPTION
The neon-beat-controller firmware is currently built with buildroot 2025.02.x, which brings cargo 1.82.0. With this cargo version, edition 2024 is still marked as unstable, thus preventing the backend build without customizations to bring a fresher cargo.

The Neon Beat backend does not seem to depend on any specific feature from the 2024 edition: when set to 2021 instead of 2024:
- it builds correctly
- the backend properly starts and run

Allow compatibility with current NBC build system by decreasing the needed Rust edition.