### PR TITLE
couchdb: remove unused member from AllDocsRow

### DIFF
--- a/src/dao/game_store/couchdb/models.rs
+++ b/src/dao/game_store/couchdb/models.rs
@@ -21,7 +21,6 @@ pub struct AllDocsResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct AllDocsRow {
-    pub id: String,
     #[serde(default)]
     pub doc: Option<Value>,
 }


### PR DESCRIPTION
Building the backend triggers the following warning:

  warning: field `id` is never read
    --> src/dao/game_store/couchdb/models.rs:24:9
     |
  23 | pub struct AllDocsRow {
     |            ---------- field in this struct
  24 |     pub id: String,
     |         ^^
     |
     = note: `AllDocsRow` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
     = note: `#[warn(dead_code)]` on by default

Fix the warning by dropping the unused member.